### PR TITLE
Correct the order of arguments passed for compare

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -113,7 +113,7 @@ func Write(t tb, tar target, bs []byte) {
 // updating golden files using the command line flag.
 func (tool Tool) Assert(got []byte) {
 	tool.Update(got)
-	tool.compare(tool.SetTarget(Golden).Read(), got)
+	tool.compare(got, tool.SetTarget(Golden).Read())
 }
 
 // Path is getter to get the path to the file containing the test data.

--- a/testdata/TestAssert/failure-assert-data.golden
+++ b/testdata/TestAssert/failure-assert-data.golden
@@ -1,5 +1,5 @@
 {
 	"fats": [
-		"golden: compare error got = \"Z29sZGVu\", want \"golden\""
+		"golden: compare error got = \"golden\", want \"Z29sZGVu\""
 	]
 }

--- a/testdata/TestTool_Assert/failure-assert-data.golden
+++ b/testdata/TestTool_Assert/failure-assert-data.golden
@@ -1,5 +1,5 @@
 {
 	"fats": [
-		"golden: compare error got = \"Z29sZGVu\", want \"golden\""
+		"golden: compare error got = \"golden\", want \"Z29sZGVu\""
 	]
 }


### PR DESCRIPTION
Correcting an error that results in an incorrect error message.