### PR TITLE
 Make the default read from input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ your own codebase, such as reading from an input file.
 
 ```go
 func TestDecode(t *testing.T) {
-    input := string(golden.Read(t, golden.Input))
+    input := string(golden.Read(t))
     got, err := base64.RawURLEncoding.DecodeString(input)
     if err != nil {
         t.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -48,7 +48,7 @@ func ExampleRun() {
 //
 // The test name is assumed to be equal to ExampleRead.
 func ExampleRead() {
-	input := string(golden.Read(t, golden.Input))
+	input := string(golden.Read(t))
 	got, err := base64.RawURLEncoding.DecodeString(input)
 	if err != nil {
 		t.Fatal(err)

--- a/golden.go
+++ b/golden.go
@@ -89,8 +89,8 @@ func Assert(t tb, got []byte) {
 
 // Read is a functional for reading both input and golden files using
 // the appropriate target.
-func Read(t tb, tar target) []byte {
-	return tool.SetTest(t).SetTarget(tar).Read()
+func Read(t tb) []byte {
+	return tool.SetTest(t).SetTarget(Input).Read()
 }
 
 // Run is a functional that automates the process of reading the input file

--- a/golden_test.go
+++ b/golden_test.go
@@ -170,6 +170,7 @@ func TestRead(t *testing.T) {
 
 			tool.readFile = func(filename string) (bytes []byte, e error) {
 				t.Logf(`os.ReadFile(%q) `, filename)
+				helper.SetTest(t).SetPrefix("filename").Assert([]byte(filename))
 				return tt.readFile.bytes, tt.readFile.error
 			}
 			defer func() {

--- a/golden_test.go
+++ b/golden_test.go
@@ -110,7 +110,6 @@ func TestAssert(t *testing.T) {
 func TestRead(t *testing.T) {
 	type args struct {
 		test *FakeTest
-		tar  target
 	}
 	type readFile struct {
 		error error
@@ -128,7 +127,6 @@ func TestRead(t *testing.T) {
 			want: []byte("golden"),
 			args: args{
 				test: new(FakeTest),
-				tar:  Golden,
 			},
 			readFile: readFile{
 				bytes: []byte("golden"),
@@ -141,7 +139,6 @@ func TestRead(t *testing.T) {
 			want: nil,
 			args: args{
 				test: new(FakeTest),
-				tar:  Golden,
 			},
 			readFile: readFile{
 				bytes: nil,
@@ -154,7 +151,6 @@ func TestRead(t *testing.T) {
 			want: nil,
 			args: args{
 				test: new(FakeTest),
-				tar:  Golden,
 			},
 			readFile: readFile{
 				bytes: nil,
@@ -180,7 +176,7 @@ func TestRead(t *testing.T) {
 				tt.args.test.Assert(t)
 			}()
 			tt.args.test.name = t.Name()
-			got := Read(tt.args.test, tt.args.tar)
+			got := Read(tt.args.test)
 			if !bytes.Equal(got, tt.want) {
 				t.Errorf("Read() = %v, want %v", got, tt.want)
 			}

--- a/testdata/TestRead/error-reading-file-permission-denied.filename.golden
+++ b/testdata/TestRead/error-reading-file-permission-denied.filename.golden
@@ -1,0 +1,1 @@
+testdata/TestRead/error-reading-file-permission-denied.golden

--- a/testdata/TestRead/error-reading-file-permission-denied.filename.golden
+++ b/testdata/TestRead/error-reading-file-permission-denied.filename.golden
@@ -1,1 +1,1 @@
-testdata/TestRead/error-reading-file-permission-denied.golden
+testdata/TestRead/error-reading-file-permission-denied.input

--- a/testdata/TestRead/success-read-data.filename.golden
+++ b/testdata/TestRead/success-read-data.filename.golden
@@ -1,0 +1,1 @@
+testdata/TestRead/success-read-data.golden

--- a/testdata/TestRead/success-read-data.filename.golden
+++ b/testdata/TestRead/success-read-data.filename.golden
@@ -1,1 +1,1 @@
-testdata/TestRead/success-read-data.golden
+testdata/TestRead/success-read-data.input

--- a/testdata/TestRead/success-read-nil.filename.golden
+++ b/testdata/TestRead/success-read-nil.filename.golden
@@ -1,1 +1,1 @@
-testdata/TestRead/success-read-nil.golden
+testdata/TestRead/success-read-nil.input

--- a/testdata/TestRead/success-read-nil.filename.golden
+++ b/testdata/TestRead/success-read-nil.filename.golden
@@ -1,0 +1,1 @@
+testdata/TestRead/success-read-nil.golden

--- a/testdata/TestRead/success-read-nil.golden
+++ b/testdata/TestRead/success-read-nil.golden
@@ -1,5 +1,5 @@
 {
 	"logs": [
-		"golden: read the value of nil since it is not found file: testdata/TestRead/success-read-nil.golden"
+		"golden: read the value of nil since it is not found file: testdata/TestRead/success-read-nil.input"
 	]
 }


### PR DESCRIPTION
Most often, reading is required for input files, and this is what
defines the standard behavior for reading. You can also read golden
files using the builder call chain.