### PR TITLE
Update tools and remove validation relevance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,5 @@ vet: ## Check the project with vet
 
 .PHONY: actual
 actual: ## Checking the relevance of dependencies, and tools. And also the absence of arbitrary changes when performing checks.
-	@$(MAKE) toolsup
 	@go mod tidy
 	@if [ -n "$(git diff)" ]; then echo "All relevant"; else git diff --exit-code; fi;

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
-	golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb
+	golang.org/x/tools v0.0.0-20190806143415-35ef2682e516
 )

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -7,5 +7,5 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb h1:Zi4or4sGkVpI7V5TX4JDMHJAthfKDKg8WotOBKXqmTs=
-golang.org/x/tools v0.0.0-20190725161231-2e34cfcb95cb/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190806143415-35ef2682e516 h1:r360bnWZkNIjtDFjRC/LVCPgL7sVglqb4XuifefgtB8=
+golang.org/x/tools v0.0.0-20190806143415-35ef2682e516/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=


### PR DESCRIPTION
Tool-related packages are often updated, for this
reason it is not convenient to constantly
update them.