### PR TITLE
Add prefix normalization

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -237,12 +238,19 @@ func (tool Tool) ok(err error) {
 
 // path is getter to get the path to the file containing the test data.
 func (tool Tool) path() (path string) {
-	s := fmt.Sprintf("%s.%s", tool.test.Name(), tool.target.String())
+	format := "%s"
+	args := []interface{}{tool.test.Name()}
+
 	if tool.prefix != "" {
-		s = fmt.Sprintf("%s.%s.%s", tool.test.Name(), tool.prefix, tool.target.String())
+		args = append(args, tool.prefix)
 	}
 
-	return filepath.Join(tool.dir, s)
+	// Add a target extansion. Always added last.
+	args = append(args, tool.target.String())
+	// We add placeholders for the number of parameters excluding the name
+	// of the test to print all the parameters.
+	format += strings.Repeat(".%s", len(args)-1)
+	return filepath.Join(tool.dir, fmt.Sprintf(format, args...))
 }
 
 // rewrite rewrites a subname to having only printable characters and no white

--- a/golden.go
+++ b/golden.go
@@ -11,6 +11,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -151,7 +153,7 @@ func (tool Tool) Run(do func(input []byte) (got []byte, err error)) {
 
 // SetPrefix a prefix value setter.
 func (tool Tool) SetPrefix(prefix string) Tool {
-	tool.prefix = prefix
+	tool.prefix = rewrite(prefix)
 	return tool
 }
 
@@ -241,4 +243,22 @@ func (tool Tool) path() (path string) {
 	}
 
 	return filepath.Join(tool.dir, s)
+}
+
+// rewrite rewrites a subname to having only printable characters and no white
+// space.
+func rewrite(str string) string {
+	bs := make([]byte, 0, len(str))
+	for _, b := range str {
+		switch {
+		case unicode.IsSpace(b):
+			bs = append(bs, '_')
+		case !strconv.IsPrint(b):
+			s := strconv.QuoteRune(b)
+			bs = append(bs, s[1:len(s)-1]...)
+		default:
+			bs = append(bs, string(b)...)
+		}
+	}
+	return string(bs)
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -386,6 +386,11 @@ func TestTool_path(t *testing.T) {
 			tool: tool.SetTarget(Golden).SetPrefix("gold"),
 			path: "testdata/TestTool_path/path-target-golden-prefix-gold.gold.golden",
 		},
+		{
+			name: "path-prefix-with-spaces",
+			tool: tool.SetTarget(Golden).SetPrefix("path prefix with spaces"),
+			path: "testdata/TestTool_path/path-prefix-with-spaces.path prefix with spaces.golden",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/golden_test.go
+++ b/golden_test.go
@@ -352,39 +352,46 @@ func TestTool_Assert(t *testing.T) {
 
 func TestTool_path(t *testing.T) {
 	tests := []struct {
-		name     string
-		tool     Tool
-		wantPath string
+		name string
+		path string
+		tool Tool
 	}{
 		{
 			name: "empty",
 			tool: Tool{},
+			path: "TestTool_path/empty.golden",
 		},
 		{
 			name: "default",
 			tool: tool,
+			path: "testdata/TestTool_path/default.golden",
 		},
 		{
 			name: "path-target-input",
 			tool: tool.SetTarget(Input),
+			path: "testdata/TestTool_path/path-target-input.input",
 		},
 		{
 			name: "path-target-golden",
 			tool: tool.SetTarget(Golden),
+			path: "testdata/TestTool_path/path-target-golden.golden",
 		},
 		{
 			name: "path-target-input-prefix-gold",
 			tool: tool.SetTarget(Input).SetPrefix("gold"),
+			path: "testdata/TestTool_path/path-target-input-prefix-gold.gold.input",
 		},
 		{
 			name: "path-target-golden-prefix-gold",
 			tool: tool.SetTarget(Golden).SetPrefix("gold"),
+			path: "testdata/TestTool_path/path-target-golden-prefix-gold.gold.golden",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			test := &FakeTest{name: t.Name()}
-			helper.SetTest(t).Assert([]byte(tt.tool.SetTest(test).path()))
+			if got := tt.tool.SetTest(t).path(); got != tt.path {
+				t.Fatalf("error want path %q, actual %q", tt.path, got)
+			}
 		})
 	}
 }

--- a/golden_test.go
+++ b/golden_test.go
@@ -389,7 +389,7 @@ func TestTool_path(t *testing.T) {
 		{
 			name: "path-prefix-with-spaces",
 			tool: tool.SetTarget(Golden).SetPrefix("path prefix with spaces"),
-			path: "testdata/TestTool_path/path-prefix-with-spaces.path prefix with spaces.golden",
+			path: "testdata/TestTool_path/path-prefix-with-spaces.path_prefix_with_spaces.golden",
 		},
 	}
 	for _, tt := range tests {
@@ -1075,6 +1075,42 @@ func Test_target_String(t *testing.T) {
 					t.Errorf("target.String() = %v, want %v", got, tt.want)
 				}
 			}()
+		})
+	}
+}
+
+func Test_rewrite(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "simple case with spaces",
+			arg:  "simple case with spaces",
+			want: "simple_case_with_spaces",
+		},
+		{
+			name: "simple case with tab",
+			arg:  "simple case with\ttab",
+			want: "simple_case_with_tab",
+		},
+		{
+			name: "simple case with new line",
+			arg:  "simple case with" + "\n" + "new line",
+			want: "simple_case_with_new_line",
+		},
+		{
+			name: "incorrect rune(0)",
+			arg:  "simple case with" + string(rune(0)),
+			want: `simple_case_with\x00`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rewrite(tt.arg); got != tt.want {
+				t.Errorf("rewrite() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/testdata/TestTool_path/default.golden
+++ b/testdata/TestTool_path/default.golden
@@ -1,1 +1,0 @@
-testdata/TestTool_path/default.golden

--- a/testdata/TestTool_path/empty.golden
+++ b/testdata/TestTool_path/empty.golden
@@ -1,1 +1,0 @@
-TestTool_path/empty.golden

--- a/testdata/TestTool_path/path-target-golden-prefix-gold.golden
+++ b/testdata/TestTool_path/path-target-golden-prefix-gold.golden
@@ -1,1 +1,0 @@
-testdata/TestTool_path/path-target-golden-prefix-gold.gold.golden

--- a/testdata/TestTool_path/path-target-golden.golden
+++ b/testdata/TestTool_path/path-target-golden.golden
@@ -1,1 +1,0 @@
-testdata/TestTool_path/path-target-golden.golden

--- a/testdata/TestTool_path/path-target-input-prefix-gold.golden
+++ b/testdata/TestTool_path/path-target-input-prefix-gold.golden
@@ -1,1 +1,0 @@
-testdata/TestTool_path/path-target-input-prefix-gold.gold.input

--- a/testdata/TestTool_path/path-target-input.golden
+++ b/testdata/TestTool_path/path-target-input.golden
@@ -1,1 +1,0 @@
-testdata/TestTool_path/path-target-input.input


### PR DESCRIPTION
1. Bug fix with no normalization prefix
1. This test becomes more readable when there is path data in the tabular
part of the test.