### PR TITLE
Manual setting of the want data

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -80,21 +80,21 @@ func init() {
 // Assert is a tool to compare the actual value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func Assert(t TestingTB, actual []byte) {
+func Assert(t TestingTB, got []byte) {
 	if h, ok := t.(testingHelper); ok {
 		h.Helper()
 	}
-	SetTest(t).Assert(actual)
+	SetTest(t).Assert(got)
 }
 
 // Equal is a tool to compare the actual value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func Equal(t TestingTB, actual []byte) Conclusion {
+func Equal(t TestingTB, got []byte) Conclusion {
 	if h, ok := t.(testingHelper); ok {
 		h.Helper()
 	}
-	return SetTest(t).Equal(actual)
+	return SetTest(t).Equal(got)
 }
 
 // Read is a functional for reading both input and golden files using
@@ -119,35 +119,35 @@ func SetTest(t TestingTB) Tool {
 // Assert is a tool to compare the actual value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func (t Tool) Assert(actual []byte) {
-	t.Update(actual)
+func (t Tool) Assert(got []byte) {
+	t.Update(got)
 	if h, ok := t.test.(testingHelper); ok {
 		h.Helper()
 	}
-	t.Equal(actual).FailNow()
+	t.Equal(got).FailNow()
 }
 
 // Equal is a tool to compare the actual value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func (t Tool) Equal(actual []byte) Conclusion {
-	t.Update(actual)
+func (t Tool) Equal(got []byte) Conclusion {
+	t.Update(got)
 	if h, ok := t.test.(testingHelper); ok {
 		h.Helper()
 	}
 
-	expected := t.SetTarget(Golden).Read()
+	want := t.SetTarget(Golden).Read()
 
-	if expected == nil {
-		expected = []byte(fmt.Sprintf("%#v", expected))
+	if want == nil {
+		want = []byte(fmt.Sprintf("%#v", want))
 	}
-	if actual == nil {
-		actual = []byte(fmt.Sprintf("%#v", actual))
+	if got == nil {
+		got = []byte(fmt.Sprintf("%#v", got))
 	}
 
 	i := new(interceptor)
 	c := newConclusion(t.test)
-	c.successful = assert.Equal(i, string(expected), string(actual))
+	c.successful = assert.Equal(i, string(want), string(got))
 	c.diff = i
 
 	return c
@@ -156,23 +156,23 @@ func (t Tool) Equal(actual []byte) Conclusion {
 // JSONEq is a tool to compare the actual JSON value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func (t Tool) JSONEq(actual string) Conclusion {
+func (t Tool) JSONEq(got string) Conclusion {
 	if h, ok := t.test.(testingHelper); ok {
 		h.Helper()
 	}
 
-	return t.jsonEqual(actual)
+	return t.jsonEqual(got)
 }
 
-func (t Tool) jsonEqual(actual string) conclusion {
+func (t Tool) jsonEqual(got string) conclusion {
 	t.setExtension("json").update(func() []byte {
-		return []byte(jsonFormatter(t.test, actual))
+		return []byte(jsonFormatter(t.test, got))
 	})
 
-	expected := t.setExtension("json").SetTarget(Golden).Read()
+	want := t.setExtension("json").SetTarget(Golden).Read()
 	i := new(interceptor)
 	c := newConclusion(t.test)
-	c.successful = assert.JSONEq(i, string(expected), string(actual))
+	c.successful = assert.JSONEq(i, string(want), string(got))
 	c.diff = i
 	return c
 }
@@ -180,12 +180,12 @@ func (t Tool) jsonEqual(actual string) conclusion {
 // JSONEq is a tool to compare the actual JSON value obtained in the test and
 // the value from the golden file. Also, built-in functionality for
 // updating golden files using the command line flag.
-func JSONEq(tb TestingTB, actual string) Conclusion {
+func JSONEq(tb TestingTB, got string) Conclusion {
 	if h, ok := tb.(testingHelper); ok {
 		h.Helper()
 	}
 
-	return _golden.SetTest(tb).jsonEqual(actual)
+	return _golden.SetTest(tb).jsonEqual(got)
 }
 
 // Read is a functional for reading both input and golden files using
@@ -207,7 +207,7 @@ func (t Tool) Read() (bs []byte) {
 // Run is a functional that automates the process of reading the input file
 // of the test bytes and the execution of the input function of testing and
 // checking the results.
-func (t Tool) Run(do func(input []byte) (actual []byte, err error)) {
+func (t Tool) Run(do func(input []byte) (got []byte, err error)) {
 	bs, err := do(t.SetTarget(Input).Read())
 	t.noError(err)
 	t.Assert(bs)

--- a/golden_test.go
+++ b/golden_test.go
@@ -476,6 +476,12 @@ func TestTool_Read(t *testing.T) {
 			}
 		})
 	}
+	t.Run("with-set-want-field", func(t *testing.T) {
+		tb := &bufferTB{name: t.Name()}
+		tool := SetWant(tb, []byte(t.Name()))
+		assert.Equal(t, t.Name(), string(tool.Read()))
+		_goldie.SetTest(t).Assert(tb.Bytes())
+	})
 }
 
 func TestTool_Run(t *testing.T) {

--- a/golden_test.go
+++ b/golden_test.go
@@ -948,59 +948,59 @@ func TestTool_Equal(t *testing.T) {
 	type args struct {
 	}
 	tests := []struct {
-		name     string
-		args     args
-		actual   []byte
-		expected []byte
-		failed   bool
+		name   string
+		args   args
+		got    []byte
+		want   []byte
+		failed bool
 	}{
 		{
-			name:     "successful nil-nil",
-			expected: nil,
-			actual:   nil,
-			failed:   false,
+			name:   "successful nil-nil",
+			want:   nil,
+			got:    nil,
+			failed: false,
 		},
 		{
-			name:     "successful []-[]",
-			expected: []byte{},
-			actual:   []byte{},
-			failed:   false,
+			name:   "successful []-[]",
+			want:   []byte{},
+			got:    []byte{},
+			failed: false,
 		},
 		{
-			name:     "successful golden-golden",
-			expected: []byte("golden"),
-			actual:   []byte("golden"),
-			failed:   false,
+			name:   "successful golden-golden",
+			want:   []byte("golden"),
+			got:    []byte("golden"),
+			failed: false,
 		},
 		{
-			name:     "failure golden-Z29sZGVu",
-			expected: []byte("golden"),
-			actual:   []byte("Z29sZGVu"),
-			failed:   true,
+			name:   "failure golden-Z29sZGVu",
+			want:   []byte("golden"),
+			got:    []byte("Z29sZGVu"),
+			failed: true,
 		},
 		{
-			name:     "failure golden-nil",
-			expected: []byte("golden"),
-			actual:   nil,
-			failed:   true,
+			name:   "failure golden-nil",
+			want:   []byte("golden"),
+			got:    nil,
+			failed: true,
 		},
 		{
-			name:     "failure nil-golden",
-			expected: nil,
-			actual:   []byte("golden"),
-			failed:   true,
+			name:   "failure nil-golden",
+			want:   nil,
+			got:    []byte("golden"),
+			failed: true,
 		},
 		{
-			name:     "failure []-nil",
-			expected: []byte{},
-			actual:   nil,
-			failed:   true,
+			name:   "failure []-nil",
+			want:   []byte{},
+			got:    nil,
+			failed: true,
 		},
 		{
-			name:     "failure nil-[]",
-			expected: nil,
-			actual:   []byte{},
-			failed:   true,
+			name:   "failure nil-[]",
+			want:   nil,
+			got:    []byte{},
+			failed: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1008,9 +1008,9 @@ func TestTool_Equal(t *testing.T) {
 			tb := &bufferTB{name: t.Name()}
 			tool := _golden.SetTest(tb)
 			tool.mkdirAll = func(path string, perm os.FileMode) error { return nil }
-			tool.readFile = helperOSReadFile(t, tt.expected, nil)
+			tool.readFile = helperOSReadFile(t, tt.want, nil)
 
-			conclusion := tool.Equal(tt.actual)
+			conclusion := tool.Equal(tt.got)
 			conclusion.Fail()
 			if conclusion.Failed() {
 				assert.Panics(t, func() {
@@ -1032,59 +1032,59 @@ func TestEqual(t *testing.T) {
 	type args struct {
 	}
 	tests := []struct {
-		name     string
-		args     args
-		actual   []byte
-		expected []byte
-		failed   bool
+		name   string
+		args   args
+		got    []byte
+		want   []byte
+		failed bool
 	}{
 		{
-			name:     "successful nil-nil",
-			expected: nil,
-			actual:   nil,
-			failed:   false,
+			name:   "successful nil-nil",
+			want:   nil,
+			got:    nil,
+			failed: false,
 		},
 		{
-			name:     "successful []-[]",
-			expected: []byte{},
-			actual:   []byte{},
-			failed:   false,
+			name:   "successful []-[]",
+			want:   []byte{},
+			got:    []byte{},
+			failed: false,
 		},
 		{
-			name:     "successful golden-golden",
-			expected: []byte("golden"),
-			actual:   []byte("golden"),
-			failed:   false,
+			name:   "successful golden-golden",
+			want:   []byte("golden"),
+			got:    []byte("golden"),
+			failed: false,
 		},
 		{
-			name:     "failure golden-Z29sZGVu",
-			expected: []byte("golden"),
-			actual:   []byte("Z29sZGVu"),
-			failed:   true,
+			name:   "failure golden-Z29sZGVu",
+			want:   []byte("golden"),
+			got:    []byte("Z29sZGVu"),
+			failed: true,
 		},
 		{
-			name:     "failure golden-nil",
-			expected: []byte("golden"),
-			actual:   nil,
-			failed:   true,
+			name:   "failure golden-nil",
+			want:   []byte("golden"),
+			got:    nil,
+			failed: true,
 		},
 		{
-			name:     "failure nil-golden",
-			expected: nil,
-			actual:   []byte("golden"),
-			failed:   true,
+			name:   "failure nil-golden",
+			want:   nil,
+			got:    []byte("golden"),
+			failed: true,
 		},
 		{
-			name:     "failure []-nil",
-			expected: []byte{},
-			actual:   nil,
-			failed:   true,
+			name:   "failure []-nil",
+			want:   []byte{},
+			got:    nil,
+			failed: true,
 		},
 		{
-			name:     "failure nil-[]",
-			expected: nil,
-			actual:   []byte{},
-			failed:   true,
+			name:   "failure nil-[]",
+			want:   nil,
+			got:    []byte{},
+			failed: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1094,9 +1094,9 @@ func TestEqual(t *testing.T) {
 
 			tb := &bufferTB{name: t.Name()}
 			_golden.mkdirAll = func(path string, perm os.FileMode) error { return nil }
-			_golden.readFile = helperOSReadFile(t, tt.expected, nil)
+			_golden.readFile = helperOSReadFile(t, tt.want, nil)
 
-			conclusion := Equal(tb, tt.actual)
+			conclusion := Equal(tb, tt.got)
 			conclusion.Fail()
 			if conclusion.Failed() {
 				assert.Panics(t, func() {
@@ -1175,26 +1175,26 @@ func Test_jsonFormatter(t *testing.T) {
 
 func TestTool_JSONEq(t *testing.T) {
 	tests := []struct {
-		name     string
-		actual   string
-		expected string
-		failed   bool
+		name   string
+		got    string
+		want   string
+		failed bool
 	}{
 		{
-			name:     "Succeeded",
-			actual:   "{}",
-			expected: `{}`,
-			failed:   false,
+			name:   "Succeeded",
+			got:    "{}",
+			want:   `{}`,
+			failed: false,
 		},
 		{
-			name:     "Failed",
-			actual:   "{}",
-			expected: `{"data":null}`,
-			failed:   true,
+			name:   "Failed",
+			got:    "{}",
+			want:   `{"data":null}`,
+			failed: true,
 		},
 		{
 			name:   "unexpected end of JSON input",
-			actual: "",
+			got:    "",
 			failed: true,
 		},
 	}
@@ -1202,9 +1202,9 @@ func TestTool_JSONEq(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tb := &bufferTB{name: t.Name()}
 			tl := SetTest(tb)
-			tl.readFile = helperOSReadFile(t, []byte(tt.expected), nil)
+			tl.readFile = helperOSReadFile(t, []byte(tt.want), nil)
 
-			cl := tl.JSONEq(tt.actual)
+			cl := tl.JSONEq(tt.got)
 			cl.Fail()
 			if cl.Failed() {
 				assert.Panics(t, func() { cl.FailNow() })
@@ -1217,21 +1217,21 @@ func TestTool_JSONEq(t *testing.T) {
 	}
 
 	t.Run("check-for-updates", func(t *testing.T) {
-		actual := []byte("{}")
+		got := []byte("{}")
 		tb := &bufferTB{name: t.Name()}
 		tl := SetTest(tb)
 		tl.flag = new(bool)
 		*tl.flag = true
-		tl.readFile = helperOSReadFile(t, actual, nil)
+		tl.readFile = helperOSReadFile(t, got, nil)
 		tl.writeFile = func(name string, data []byte, mode os.FileMode) error {
 			assert.Equal(t, name, "testdata/TestTool_JSONEq/check-for-updates.json.golden")
-			assert.Equal(t, actual, data)
+			assert.Equal(t, got, data)
 			assert.Equal(t, tl.fileMode, mode)
 			return nil
 		}
 		tl.mkdirAll = func(string, os.FileMode) error { return nil }
 
-		cl := tl.JSONEq(string(actual))
+		cl := tl.JSONEq(string(got))
 		cl.Fail()
 		if cl.Failed() {
 			assert.Panics(t, func() { cl.FailNow() })
@@ -1245,26 +1245,26 @@ func TestTool_JSONEq(t *testing.T) {
 
 func TestJSONEq(t *testing.T) {
 	tests := []struct {
-		name     string
-		actual   string
-		expected string
-		failed   bool
+		name   string
+		got    string
+		want   string
+		failed bool
 	}{
 		{
-			name:     "Succeeded",
-			actual:   "{}",
-			expected: `{}`,
-			failed:   false,
+			name:   "Succeeded",
+			got:    "{}",
+			want:   `{}`,
+			failed: false,
 		},
 		{
-			name:     "Failed",
-			actual:   "{}",
-			expected: `{"data":null}`,
-			failed:   true,
+			name:   "Failed",
+			got:    "{}",
+			want:   `{"data":null}`,
+			failed: true,
 		},
 		{
 			name:   "unexpected end of JSON input",
-			actual: "",
+			got:    "",
 			failed: true,
 		},
 	}
@@ -1274,9 +1274,9 @@ func TestJSONEq(t *testing.T) {
 			defer func() { _golden = origin }()
 
 			tb := &bufferTB{name: t.Name()}
-			_golden.readFile = helperOSReadFile(t, []byte(tt.expected), nil)
+			_golden.readFile = helperOSReadFile(t, []byte(tt.want), nil)
 
-			cl := JSONEq(tb, tt.actual)
+			cl := JSONEq(tb, tt.got)
 			cl.Fail()
 			if cl.Failed() {
 				assert.Panics(t, func() { cl.FailNow() })

--- a/testdata/TestTool_Read/with-set-want-field.golden
+++ b/testdata/TestTool_Read/with-set-want-field.golden
@@ -1,0 +1,1 @@
+golden: read the value from the want field


### PR DESCRIPTION
feat: add the ability to manually specify the want value

This is necessary to separate data in table tests when there are few
cases with big data and there are cases with short data that are better
represented in the table.

Perhaps this method is not a good idea, since the test data is mixed,
but perhaps this opportunity will do itself well in practice.