### PR TITLE
Add support for updating files via env var

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -77,8 +77,25 @@ var _golden = Tool{
 	writeFile: ioutil.WriteFile,
 }
 
+const updateEnvName = "GOLDEN_UPDATE"
+
+func getUpdateEnv() bool {
+	env := os.Getenv(updateEnvName)
+	if env == "" {
+		env = strconv.FormatBool(false)
+	}
+
+	is, err := strconv.ParseBool(env)
+	if err != nil {
+		const msg = "cannot parse flag %q, error: %v"
+		panic(fmt.Sprintf(msg, updateEnvName, err))
+	}
+
+	return is
+}
+
 func init() {
-	_golden.flag = flag.Bool("update", false, "update test golden files")
+	_golden.flag = flag.Bool("getUpdateEnv", getUpdateEnv(), "update test golden files")
 }
 
 // Assert is a tool to compare the actual value obtained in the test and

--- a/golden_test.go
+++ b/golden_test.go
@@ -1294,3 +1294,25 @@ func TestJSONEq(t *testing.T) {
 		})
 	}
 }
+
+func Test_getUpdateEnv(t *testing.T) {
+	t.Run("received false", func(t *testing.T) {
+		assert.NoError(t, os.Setenv(updateEnvName, "false"))
+		assert.False(t, getUpdateEnv())
+	})
+	t.Run("received true", func(t *testing.T) {
+		assert.NoError(t, os.Setenv(updateEnvName, "true"))
+		assert.True(t, getUpdateEnv())
+	})
+	t.Run("parsing error", func(t *testing.T) {
+		assert.NoError(t, os.Setenv(updateEnvName, "folse"))
+		const expected = "cannot parse flag \"GOLDEN_UPDATE\", error:" +
+			" strconv.ParseBool: parsing \"folse\": invalid syntax"
+		assert.PanicsWithValue(
+			t, expected,
+			func() {
+				assert.False(t, getUpdateEnv())
+			},
+		)
+	})
+}


### PR DESCRIPTION
When updating via a flag, errors may occur when the flag is not
available in the abort of available flags in tests that do not use
golden, therefore it is proposed to use an environment variable for
these purposes.

#25