### PR TITLE
docs: replace short url with original

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ go get github.com/xorcare/golden
 
 ## Inspiration
 
- * [Golden Files — Why you should use them](http://bit.ly/2JikzYp)
+ * [Golden Files—Why you should use them](http://bit.ly/2JikzYp)
  * [Testing with golden files in Go](http://bit.ly/2TFjdvC)
  * [Go advanced testing tips & tricks](https://bit.ly/2Cpi28Q)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ go get github.com/xorcare/golden
 
 ## Inspiration
 
- * [Golden Files—Why you should use them](http://bit.ly/2JikzYp)
- * [Testing with golden files in Go](http://bit.ly/2TFjdvC)
- * [Go advanced testing tips & tricks](https://bit.ly/2Cpi28Q)
+ * [Golden Files—Why you should use them](https://medium.com/@jarifibrahim/golden-files-why-you-should-use-them-47087ec994bf)
+ * [Testing with golden files in Go](https://medium.com/soon-london/testing-with-golden-files-in-go-7fccc71c43d3)
+ * [Go advanced testing tips & tricks](https://medium.com/@povilasve/go-advanced-tips-tricks-a872503ac859)
 
 ## License
 
@@ -55,4 +55,4 @@ go get github.com/xorcare/golden
 
 Released under the [BSD 3-Clause License][LICENSE].
 
-[LICENSE]: https://git.io/fhjjx 'BSD 3-Clause "New" or "Revised" License'
+[LICENSE]: https://github.com/xorcare/golden/blob/master/LICENSE.md 'BSD 3-Clause "New" or "Revised" License'


### PR DESCRIPTION
This is necessary in order to clearly see where the link leads, having
visual control over it, and not to depend on third-party services of
short addresses.