### PR TITLE
ci: remove checks on macOS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,6 @@ jobs:
         - '1.11'
         os:
         - 'ubuntu-18.04'
-        - 'macos-10.15'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go ${{ matrix.go }}
@@ -59,7 +58,6 @@ jobs:
         - '1.8'
         os:
         - 'ubuntu-18.04'
-        - 'macos-10.15'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go ${{ matrix.go }}


### PR DESCRIPTION
Now the repository does not contain code that is tied to platforms, so
I think it makes little sense to conduct testing on the macOS platform.