### PR TITLE
docs: update license file and headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 BSD 3-Clause License
 
-Copyright © 2019, Vasiliy Vasilyuk <xorcare@gmail.com>
-All rights reserved.
+Copyright (c) 2019-2021 Vasiliy Vasilyuk <xorcare@gmail.com> All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ go get github.com/xorcare/golden
 
 ## License
 
-© Vasiliy Vasilyuk, 2019
+© Vasiliy Vasilyuk, 2019-2021
 
 Released under the [BSD 3-Clause License][LICENSE].
 

--- a/conclusion.go
+++ b/conclusion.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import "fmt"

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden_test
 
 import (

--- a/golden.go
+++ b/golden.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/interceptor.go
+++ b/interceptor.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import (

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import (

--- a/internal/integration/golden.go
+++ b/internal/integration/golden.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/integration/golden_test.go
+++ b/internal/integration/golden_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, Vasiliy Vasilyuk. All rights reserved.
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/target.go
+++ b/target.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import "fmt"

--- a/target_test.go
+++ b/target_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import (

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Vasiliy Vasilyuk. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golden
 
 import (


### PR DESCRIPTION
docs: update license file and headers

The copyright format has been changed to match the one specified on
https://spdx.org/licenses/BSD-3-Clause.html

Renamed the license file to match the copyright notice in the headers,
and this is also the more common name for the license file.

The license headers themselves were originally made following the
example of the open source repository by google.

Registration of a copyright notice in the README.md made in the style
of GOST R 7.0.1-2003

