### PR TITLE
docs: fix the link to the license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ go get github.com/xorcare/golden
 
 Released under the [BSD 3-Clause License][LICENSE].
 
-[LICENSE]: https://github.com/xorcare/golden/blob/master/LICENSE.md 'BSD 3-Clause "New" or "Revised" License'
+[LICENSE]: https://github.com/xorcare/golden/blob/master/LICENSE 'BSD 3-Clause "New" or "Revised" License'


### PR DESCRIPTION
When updating the license, I forgot to change the link to the license
file. I'll fix it now.