### PR TITLE
fix: remove creation of file when want set manually

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -334,7 +334,7 @@ func (t Tool) path() (path string) {
 }
 
 func (t Tool) update(f func() []byte) {
-	if t.flag != nil && *t.flag {
+	if t.flag != nil && *t.flag && t.want == nil {
 		t.test.Logf("golden: updating file: %s", t.path())
 		t.write(f())
 	}

--- a/golden_test.go
+++ b/golden_test.go
@@ -1294,3 +1294,30 @@ func TestJSONEq(t *testing.T) {
 		})
 	}
 }
+
+func TestTool_SetWant(t *testing.T) {
+	t.Run("Golden file should not be created if want is set manually", func(t *testing.T) {
+		tool := SetTest(&bufferTB{name: t.Name()})
+		// Flag has been set to explicitly indicate the need to update gold files.
+		tool.flag = &[]bool{true}[0]
+
+		tool.writeFile = func(name string, data []byte, mode os.FileMode) error {
+			t.Fatal("golden file should not be created if want is set manually")
+			return nil
+		}
+
+		value := []byte("any value")
+		cl := tool.SetWant(value).Equal(value)
+		assert.False(t, cl.Failed())
+	})
+	t.Run("If we specify nil we must subtract the data from the golden file", func(t *testing.T) {
+		tool := SetTest(&bufferTB{name: t.Name()})
+
+		goldenFileContent := []byte("any value")
+		tool.readFile = helperOSReadFile(t, goldenFileContent, nil)
+
+		got := []byte("any value")
+		cl := tool.SetWant(nil).Equal(got)
+		assert.False(t, cl.Failed())
+	})
+}


### PR DESCRIPTION
We do not need to create golden files in cases where the expected value
was manually specified. Before this fix, there was a bug with the fact
that we created golden files in which the data specified manually were
recorded.