### PR TITLE
test: prepare tests for new version of testify assert

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -131,8 +131,8 @@ func (t *T) Logf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	// Removed the trace, it contains line numbers and changes dynamically,
 	// it is not convenient to see in the examples.
-	re := regexp.MustCompile(`(?im)Error Trace:([\w\s:.]+)Error:`)
-	msg = re.ReplaceAllString(msg, "Error Trace:\n\tError:")
+	re := regexp.MustCompile(`(?im)^\t?Error\ Trace\:([\S\s\n]+)^\t?Error\:`)
+	msg = re.ReplaceAllString(msg, "\tError Trace:\n\tError:")
 
 	msg = strings.Replace(msg, "\t", "", -1)
 

--- a/testing_test.go
+++ b/testing_test.go
@@ -51,8 +51,8 @@ func (m *bufferTB) Helper() {
 
 func (m *bufferTB) Logf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	re := regexp.MustCompile(`(?im)Error Trace:([\w\s:.]+)Error:`)
-	msg = re.ReplaceAllString(msg, "Error Trace:\n\tError:")
+	re := regexp.MustCompile(`(?im)^\t?Error\ Trace\:([\S\s\n]+)^\t?Error\:`)
+	msg = re.ReplaceAllString(msg, "\tError Trace:\n\tError:")
 	m.logs = append(m.logs, msg)
 }
 


### PR DESCRIPTION
The new version will slightly change the formatting of the output, regexp is changing because of this.