### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 ---
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xorcare/golden/security/code-scanning/2](https://github.com/xorcare/golden/security/code-scanning/2)

To address the issue, add a `permissions` key to restrict the GITHUB_TOKEN used by the workflow to the minimum necessary. In this case, all steps can work with read-only access to repository contents, as none attempt to write to the repository or modify pull requests/issues. The minimal correct fix is to add a `permissions` block with `contents: read` at the root level (beneath the `name:` entry), making this the default for all jobs in the workflow. No new methods or imports are required, and the addition should preserve all existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
